### PR TITLE
Use URL constructor on argument

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "deno.enable": true,
+  "deno.lint": true,
+  "deno.unstable": false
+}

--- a/mod.ts
+++ b/mod.ts
@@ -1,9 +1,15 @@
-export async function open(url: string): Promise<void> {
+export async function open(url: string | URL): Promise<void> {
   const programAliases = {
     windows: "explorer",
     darwin: "open",
     linux: "sensible-browser",
   };
-  const process = Deno.run({ cmd: [programAliases[Deno.build.os], url] });
+
+  const { href } = typeof url === "string" ? new URL(url) : url;
+
+  const process = Deno.run({
+    cmd: [programAliases[Deno.build.os], href],
+  });
+
   await process.status();
 }


### PR DESCRIPTION
This provides the following benefits:

- Now also accepts a URL object as the argument instead of just a string

- For strings:
  - It will coerce (fix) close-but-not-quite-correct URLs. Example:
      ```ts
      console.log(new URL('https:github.com').href); //=> "https://github.com/"
      ```
  - If the provided string cannot be parsed and coerced to a valid URL, it will now throw a TypeError